### PR TITLE
Added ParameterTypes.Count check and arg to disable "calculate max stack"

### DIFF
--- a/Greenline/CharArryPatcher.cs
+++ b/Greenline/CharArryPatcher.cs
@@ -32,6 +32,7 @@ public static class CharArrayPatcher
 
             // We are searching for System.String::.ctor(char[])
             if (!constructorDef!.DeclaringType!.IsTypeOf("System", "String")
+                && constructorDef.Signature!.ParameterTypes.Count > 0
                 && constructorDef.Signature!.ParameterTypes[0] is not SzArrayTypeSignature
                 {
                     ElementType: ElementType.Char

--- a/Greenline/Program.cs
+++ b/Greenline/Program.cs
@@ -7,7 +7,8 @@ Console.WriteLine("Greenline | Redline Stealer String Unpacker by dr4k0nia\nhttp
 
 var module = ModuleDefinition.FromFile(args[0]);
 
-bool configOnly = args.Length == 2 && args[1] == "--config-only";
+bool configOnly = args.Length > 1 && args[1] == "--config-only" || args.Length > 2 && args[2] == "--config-only";
+bool maxStack = args.Length > 1 && args[1] == "--max-stack" || args.Length > 2 && args[2] == "--max-stack";
 
 string? parsedConfig = null;
 
@@ -21,8 +22,8 @@ foreach (var type in module.GetAllTypes())
 
     if (!configOnly)
     {
-        foreach (var method in type.Methods.Where(m => m.CilMethodBody != null))
-        {
+        foreach (var method in type.Methods.Where(m => m.CilMethodBody != null)) {
+            method.CilMethodBody!.ComputeMaxStackOnBuild = !maxStack;
             CharArrayPatcher.Execute(method);
             StringReplacePatcher.Execute(method);
         }


### PR DESCRIPTION
[Fixed Parameter Count check thanks to `t`

fixed MaxStack on build thanks to Washi. Parsed new arg `--max-stack` which disables the "ComputeMaxStack" on all `CliMethodBody` objects in the main loop