### PR TITLE
Update ConfigExtractor.cs

### DIFF
--- a/Greenline/ConfigExtractor.cs
+++ b/Greenline/ConfigExtractor.cs
@@ -55,8 +55,22 @@ public static class ConfigExtractor
 
     private static string Decrypt(string input, string key)
     {
-        string first = FromBase64(input);
-        return FromBase64(Xor(first, key));
+        bool Base64String = IsBase64String(input);
+        if (Base64String)
+        {
+            string first = FromBase64(input);
+            return FromBase64(Xor(first, key));
+        }
+        else
+        {
+            return input;
+        }
+    }
+
+    public static bool IsBase64String(string base64)
+    {
+        Span<byte> buffer = new Span<byte>(new byte[base64.Length]);
+        return Convert.TryFromBase64String(base64, buffer, out int bytesParsed);
     }
 
     private static string FromBase64(string base64Str)

--- a/Greenline/ConfigExtractor.cs
+++ b/Greenline/ConfigExtractor.cs
@@ -56,21 +56,20 @@ public static class ConfigExtractor
     private static string Decrypt(string input, string key)
     {
         bool Base64String = IsBase64String(input);
-        if (Base64String)
-        {
-            string first = FromBase64(input);
-            return FromBase64(Xor(first, key));
-        }
-        else
-        {
-            return input;
-        }
+        
+       if (IsBase64String(input))
+       {
+           string first = FromBase64(input);
+           return FromBase64(Xor(first, key));
+       }
+       
+       return input;
     }
 
     public static bool IsBase64String(string base64)
     {
         Span<byte> buffer = new Span<byte>(new byte[base64.Length]);
-        return Convert.TryFromBase64String(base64, buffer, out int bytesParsed);
+        return Convert.TryFromBase64String(base64, buffer, out int _);
     }
 
     private static string FromBase64(string base64Str)


### PR DESCRIPTION
For some samples "ID" parameter is not encoded in Base64 , So Adding check for it while decoding the string. 
ref sample : https://bazaar.abuse.ch/sample/30eeb6c732a7e37cbfff0148d2c2457229fb6ef36feb0abb99e2afbfed0d1257/